### PR TITLE
fix component mapping

### DIFF
--- a/packages/reactful-commands/bin/_reactful_commands.js
+++ b/packages/reactful-commands/bin/_reactful_commands.js
@@ -22,8 +22,13 @@ async function runCommand(command) {
 }
 
 async function createComponent(componentType, ...args) {
+  const COMPONENT_MAPPING = {
+    'full' : 'rcc',
+    'pure' : 'rpc',
+    'function': 'rfc'
+  }
   try {
-    await require('../lib/create-component')(componentType, ...args);
+    await require('../lib/create-component')(COMPONENT_MAPPING[componentType], ...args);
   } catch (err) {
     console.error(err);
   }


### PR DESCRIPTION
This fixes below error:

```
PS C:\Users\someena\wkspace\phoenix> react pc WidgetChart

> phoenix@0.1.0 _reactful_commands C:\Users\someena\wkspace\phoenix
> _reactful_commands "pc" "WidgetChart"

Generating src\components\WidgetChart.js
TypeError: componentCode is not a function
    at Promise (C:\Users\someena\wkspace\phoenix\node_modules\reactful-commands\lib\create-component.js:17:39)
    at Promise (<anonymous>)
    at createComponent (C:\Users\someena\wkspace\phoenix\node_modules\reactful-commands\lib\create-component.js:9:10)
    at createComponent (C:\Users\someena\wkspace\phoenix\node_modules\reactful-commands\bin\_reactful_commands.js:26:45)
    at Object.<anonymous> (C:\Users\someena\wkspace\phoenix\node_modules\reactful-commands\bin\_reactful_commands.js:44:5)
    at Module._compile (module.js:624:30)
    at Object.Module._extensions..js (module.js:635:10)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
    at Function.Module._load (module.js:500:3)
```